### PR TITLE
Fix linting and formatting commands to use project path

### DIFF
--- a/libs/cli/commands/new.ts
+++ b/libs/cli/commands/new.ts
@@ -54,7 +54,7 @@ async function createAngularProject(
   cpSync(`${originPath}/ui/theme/grid.css`, `${name}/src/theme/grid.css`);
   cpSync(`${originPath}/ui/generate-icons.js`, `${name}/generate-icons.js`);
 
-  runCommand(`${pm.run} generate-icons.js`, {
+  await runCommand('node generate-icons.js', {
     cwd: name,
     verbose,
     loaderText: 'Generating icons',

--- a/libs/cli/utils/setup-existing-project.ts
+++ b/libs/cli/utils/setup-existing-project.ts
@@ -216,12 +216,12 @@ export async function setupExistingProject(projectName: string, verbose = false)
   const pm = detectPackageManager(projectName);
 
   await runCommand(getProjectExecCommand(pm, 'eslint . --fix'), {
-    cwd: projectName,
+    cwd: projectPath,
     verbose,
     loaderText: 'Linting project',
   });
   await runCommand(getProjectExecCommand(pm, 'prettier . --write'), {
-    cwd: projectName,
+    cwd: projectPath,
     verbose,
     loaderText: 'Formatting project',
   });

--- a/libs/cli/utils/setup-existing-project.unit.spec.ts
+++ b/libs/cli/utils/setup-existing-project.unit.spec.ts
@@ -269,6 +269,58 @@ describe('setupExistingProject', () => {
     // Note: cpSync might not be properly mocked with vi.mock, but we can verify the intent
   });
 
+  it('should run lint and format using project path as cwd', async () => {
+    const { validateAngularProject } = await import('./validate-project');
+    const { detectTestFramework } = await import('./detect-test-framework');
+    const { detectPackageManager } = await import('./package-manager');
+    const { getProjectExecCommand } = await import('./package-manager');
+    const { runCommand } = await import('./run-command');
+
+    vi.mocked(validateAngularProject).mockReturnValue({
+      isValid: true,
+      isAngular: true,
+      isStandalone: true,
+      hasPackageJson: true,
+      hasTsConfig: true,
+      errors: [],
+    });
+
+    vi.mocked(detectTestFramework).mockReturnValue({
+      unit: 'vitest',
+      e2e: 'none',
+      hasTestScripts: true,
+    });
+
+    vi.mocked(detectPackageManager).mockReturnValue('npm');
+    vi.mocked(getProjectExecCommand).mockImplementation((_pm, cmd) => `npx ${cmd}`);
+
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.mkdirSync).mockReturnValue('');
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        scripts: {},
+        dependencies: { '@koalarx/utils': '1.0.0', clsx: '1.0.0' },
+        devDependencies: {},
+      }),
+    );
+
+    await setupExistingProject('test-project');
+
+    const lintCall = vi.mocked(runCommand).mock.calls.find((call) =>
+      call[0]?.toString().includes('eslint'),
+    );
+    const formatCall = vi.mocked(runCommand).mock.calls.find((call) =>
+      call[0]?.toString().includes('prettier'),
+    );
+
+    expect(lintCall?.[1]).toEqual(
+      expect.objectContaining({ cwd: '/test/projects/test-project' }),
+    );
+    expect(formatCall?.[1]).toEqual(
+      expect.objectContaining({ cwd: '/test/projects/test-project' }),
+    );
+  });
+
   it('should handle verbose mode', async () => {
     const { validateAngularProject } = await import('./validate-project');
     const { detectTestFramework } = await import('./detect-test-framework');

--- a/libs/ui/src/app/core/constants/app-version.ts
+++ b/libs/ui/src/app/core/constants/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.20.2';
+export const APP_VERSION = '0.20.3';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koalarx/ui-cli",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "scripts": {
     "build": "bun scripts/build",
     "build:doc": "cd libs/ui && bun run build:prod",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small CLI behavior fixes and a patch version bump with no security or data-handling impact.
> 
> **Overview**
> Fixes **existing-project setup** so ESLint and Prettier run with `cwd` set to the resolved **project path** (`getProjectPath`) instead of the bare project name, matching how other CLI flows (e.g. install) invoke those commands.
> 
> For **new projects**, icon generation is invoked with **`node generate-icons.js`** instead of going through the package manager’s `run` script.
> 
> Adds a **unit test** asserting lint/format `runCommand` calls use the mocked project path as `cwd`, and bumps the package/UI version to **0.20.3**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a395318ac7331806b28bba2b7f4afd9e09288b31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->