### PR TITLE
Fix package.json path in CLI runner for local build compatibility

### DIFF
--- a/libs/cli/runner.ts
+++ b/libs/cli/runner.ts
@@ -7,7 +7,8 @@ import { PackageManager } from './utils/package-manager';
 
 function getCliVersion(): string {
   try {
-    const packageJsonPath = path.resolve(__dirname, '../../package.json');
+    // runner.js lives in `<packageRoot>/cli/` (published) or `<packageRoot>/dist/cli/` (local build)
+    const packageJsonPath = path.resolve(__dirname, '../package.json');
     const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
     const packageJson = JSON.parse(packageJsonContent) as { version?: string };
 

--- a/libs/ui/src/app/core/constants/app-version.ts
+++ b/libs/ui/src/app/core/constants/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.20.3';
+export const APP_VERSION = '0.20.4';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koalarx/ui-cli",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "scripts": {
     "build": "bun scripts/build",
     "build:doc": "cd libs/ui && bun run build:prod",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small path fix and patch version bump; only affects `kl version` / `--version` reporting.
> 
> **Overview**
> Fixes **`getCliVersion()`** so it reads the root **`package.json`** via **`../package.json`** instead of **`../../package.json`**, matching where **`runner.js`** actually lives after a local build (`dist/cli/`) or when published (`cli/`). A short comment documents both layouts.
> 
> Releases **0.20.4** by bumping **`package.json`** and syncing **`APP_VERSION`** in the UI constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27e5262e6099f33dcfb3595fed0ccc23fc8b20d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->